### PR TITLE
Add yargs to avoid error when using.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
     "child",
     "process",
     "detached"
-  ]
+  ],
+  "dependencies":{
+    "yargs": "^3.29.0"
+  }
 }


### PR DESCRIPTION
When I tried to use `electron-detach` I had to add `yargs` to my package.json in order to get it to work. So, this should just be able to install it's own dependencies. 
